### PR TITLE
Move the NODE_ENV in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: false
 language: node_js
 node_js:
     - '0.12'
+env:
+    - NODE_ENV=development
 install:
-    - export NODE_ENV=development
     - npm install
     - cp package.json test/mock-project/package.json
     - cd test/mock-project


### PR DESCRIPTION
## Description
Move the NODE_ENV variable to the environment variable section of the .travisrc file rather than doing it manually during the instal process

## Todos
> Make sure you’ve completed these:

- [x] Does this feature run on all supported platforms?
- [ ] Are there tests around this feature?
- [ ] Is there documentation for this feature?

